### PR TITLE
🐛 [-bug] Fixed issue in main workflow for Common_Foundation

### DIFF
--- a/.github/actions/activate/action.yml
+++ b/.github/actions/activate/action.yml
@@ -9,7 +9,7 @@
 #
 #     Code Generator:         Jinja2
 #     Input Filename:         actions/activate/action.jinja2.yml
-#     Generated Date:         2022-11-09
+#     Generated Date:         2022-11-10
 #
 # ----------------------------------------------------------------------
 # ----------------------------------------------------------------------
@@ -61,7 +61,7 @@ runs:
             activate_statement = "pushd \"" + String.raw`${{ inputs.repo_dir }}` + "\" >> /dev/null && . ./Activate.sh";
           }
 
-          if("${{ inputs.configuration }}" != "None") {
+          if("${{ inputs.configuration }}" !== "None") {
             activate_statement += " ${{ inputs.configuration }}";
           }
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -113,27 +113,45 @@ runs:
       with:
         result-encoding: string
         script: |
-          var setup_statement;
+          var setup_statement = "pushd \" + String.raw`${{ inputs.repo_dir }}` + "\" && ";
 
-          if("${{ inputs.repo_name }}" == "davidbrownell/v4-Common_Foundation") {
-            setup_statement = "${{ inputs.sudo_command }}${{ inputs.local_script_prefix }}Setup${{ inputs.script_extension }}";
+          if("${{ inputs.repo_name }}" === "davidbrownell/v4-Common_Foundation") {
+
+            # Handle the case where the repo under test is v4-Common_Foundation and the request is for
+            # a branch/tag. In all other cases, this scenario is handled by Bootstrap/Enlist.
+            if("${{ inputs.branch_overrides }}" !== "") {
+              # In this scenario, the repo will be associated with the 'main_stable' branch. Switch
+              # to the desired branch since this repo is the repo under test.
+              var elements;
+
+              elements = "${{ inputs.branch_overrides }}".split(";");
+              console.assert(elements.length === 1, "%o", {elements});
+
+              elements = elements[0].split(":");
+              console.assert(elements.length === 2, "%o", {elements});
+              console.assert(elements[0] === "Common_Foundation", "%o", {elements[0]});
+
+              setup_statement += `git checkout "${elements[1]}" && `;
+            }
+
+            setup_statement += "${{ inputs.sudo_command }}${{ inputs.local_script_prefix }}Setup${{ inputs.script_extension }}";
           } else {
             var path = require("path");
 
-            setup_statement = "${{ inputs.sudo_command }}${{ inputs.local_script_prefix }}Bootstrap${{ inputs.script_extension }} \"" + path.join(String.raw`${{ inputs.working_dir }}`, "code") + "\"";
+            setup_statement += "${{ inputs.sudo_command }}${{ inputs.local_script_prefix }}Bootstrap${{ inputs.script_extension }} \"" + path.join(String.raw`${{ inputs.working_dir }}`, "code") + "\"";
 
-            if("${{ inputs.branch_overrides }}" != "") {
+            if("${{ inputs.branch_overrides }}" !== "") {
               setup_statement += " --branch-overrides \"${{ inputs.branch_overrides }}\"";
             }
           }
 
           setup_statement += " --no-interactive --no-hooks --debug";
 
-          if("${{ inputs.configuration }}" != "None") {
+          if("${{ inputs.configuration }}" !== "None") {
             setup_statement += " --configuration \"${{ inputs.configuration }}\"";
           }
 
-          return "pushd \"" + String.raw`${{ inputs.repo_dir }}` + "\" && " + setup_statement;
+          return setup_statement;
 
     - name: Results
       shell: ${{ inputs.shell_name }}

--- a/.github/src/actions/activate/action.jinja2.yml
+++ b/.github/src/actions/activate/action.jinja2.yml
@@ -44,7 +44,7 @@ runs:
             activate_statement = "pushd \"" + String.raw`${{ inputs.repo_dir }}` + "\" >> /dev/null && . ./Activate.sh";
           }
 
-          if("${{ inputs.configuration }}" != "None") {
+          if("${{ inputs.configuration }}" !== "None") {
             activate_statement += " ${{ inputs.configuration }}";
           }
 

--- a/.github/src/actions/setup/action.jinja2.yml
+++ b/.github/src/actions/setup/action.jinja2.yml
@@ -96,27 +96,45 @@ runs:
       with:
         result-encoding: string
         script: |
-          var setup_statement;
+          var setup_statement = "pushd \" + String.raw`${{ inputs.repo_dir }}` + "\" && ";
 
-          if("${{ inputs.repo_name }}" == "davidbrownell/v4-Common_Foundation") {
-            setup_statement = "${{ inputs.sudo_command }}${{ inputs.local_script_prefix }}Setup${{ inputs.script_extension }}";
+          if("${{ inputs.repo_name }}" === "davidbrownell/v4-Common_Foundation") {
+
+            # Handle the case where the repo under test is v4-Common_Foundation and the request is for
+            # a branch/tag. In all other cases, this scenario is handled by Bootstrap/Enlist.
+            if("${{ inputs.branch_overrides }}" !== "") {
+              # In this scenario, the repo will be associated with the 'main_stable' branch. Switch
+              # to the desired branch since this repo is the repo under test.
+              var elements;
+
+              elements = "${{ inputs.branch_overrides }}".split(";");
+              console.assert(elements.length === 1, "%o", {elements});
+
+              elements = elements[0].split(":");
+              console.assert(elements.length === 2, "%o", {elements});
+              console.assert(elements[0] === "Common_Foundation", "%o", {elements[0]});
+
+              setup_statement += `git checkout "${elements[1]}" && `;
+            }
+
+            setup_statement += "${{ inputs.sudo_command }}${{ inputs.local_script_prefix }}Setup${{ inputs.script_extension }}";
           } else {
             var path = require("path");
 
-            setup_statement = "${{ inputs.sudo_command }}${{ inputs.local_script_prefix }}Bootstrap${{ inputs.script_extension }} \"" + path.join(String.raw`${{ inputs.working_dir }}`, "code") + "\"";
+            setup_statement += "${{ inputs.sudo_command }}${{ inputs.local_script_prefix }}Bootstrap${{ inputs.script_extension }} \"" + path.join(String.raw`${{ inputs.working_dir }}`, "code") + "\"";
 
-            if("${{ inputs.branch_overrides }}" != "") {
+            if("${{ inputs.branch_overrides }}" !== "") {
               setup_statement += " --branch-overrides \"${{ inputs.branch_overrides }}\"";
             }
           }
 
           setup_statement += " --no-interactive --no-hooks --debug";
 
-          if("${{ inputs.configuration }}" != "None") {
+          if("${{ inputs.configuration }}" !== "None") {
             setup_statement += " --configuration \"${{ inputs.configuration }}\"";
           }
 
-          return "pushd \"" + String.raw`${{ inputs.repo_dir }}` + "\" && " + setup_statement;
+          return setup_statement;
 
     - name: Results
       shell: ${{ inputs.shell_name }}


### PR DESCRIPTION
When the main CI workflow is exercised in Common_Foundation, we need to set the branch to the provided branch/tag. This functionality is handled by Bootstrap & Enlist in all other scenarios.