### PR TITLE
🐛 [-bug] Fixed regression

### DIFF
--- a/RepositoryBootstrap/Impl/Setup.py
+++ b/RepositoryBootstrap/Impl/Setup.py
@@ -763,7 +763,7 @@ def _SetupBootstrap(
             ],
         )
 
-    # Find the foundation repository
+    # Find the foundation repository (we will only find this if the repo has a direct dependency on it)
     foundation_repo = None
     foundation_repo_id = uuid.UUID("DD6FCD30-B043-4058-B0D5-A6C8BC0374F4")
 
@@ -772,14 +772,14 @@ def _SetupBootstrap(
             foundation_repo = repo
             break
 
-    assert foundation_repo is not None
+    foundation_repo_root = foundation_repo.root if foundation_repo else Utilities.GetFoundationRepositoryRoot()
 
     # Update the environment so this value is used by the other activities
-    os.environ[Constants.DE_FOUNDATION_ROOT_NAME] = str(foundation_repo.root)
+    os.environ[Constants.DE_FOUNDATION_ROOT_NAME] = str(foundation_repo_root)
 
     # Create the bootstrap data
     EnvironmentBootstrap(
-        foundation_repo.root,
+        foundation_repo_root,
         repo_data.configurations,
         fingerprints,
         dependencies,

--- a/RepositoryBootstrap/Impl/Utilities.py
+++ b/RepositoryBootstrap/Impl/Utilities.py
@@ -32,7 +32,7 @@ from .. import DataTypes
 # |  Public Functions
 # |
 # ----------------------------------------------------------------------
-def GetFoundationRepository() -> Path:
+def GetFoundationRepositoryRoot() -> Path:
     """Returns the path to the foundation repository"""
 
     # Try to get the value from the environment


### PR DESCRIPTION
Fixed regression associated with 7bec2c99d3f22403cd50d9fe6e6bb04802f62bf3.

Repos that have a direct dependency on Common_Foundation will have a valid link to that repo, those that don't have a direct dependency will not. The fix is to use that information if we have it, but revert to prior behavior if we don't (which should be ok in all scenarios, as indirect dependencies will not be impacted by the issue that was addressed by the previous change).