### PR TITLE
🐛 [-bug] Fixed git regression

### DIFF
--- a/Libraries/Python/Common_Foundation/src/Common_Foundation/SourceControlManagers/GitSourceControlManager.py
+++ b/Libraries/Python/Common_Foundation/src/Common_Foundation/SourceControlManagers/GitSourceControlManager.py
@@ -990,7 +990,7 @@ class Repository(DistributedRepositoryBase):
         # Get the branch name
         branch_name: Optional[str] = None
 
-        result = GitSourceControlManager.Execute("git branch --no-color")
+        result = GitSourceControlManager.Execute(self._GetCommandLine("git branch --no-color"))
         assert result.returncode == 0, result.output
 
         if result.output:


### PR DESCRIPTION
Git was using the current working directory to get the current branch; should have been using the directory specified.