### PR TITLE
🐛 [-bug] CI scripts no longer using relative references

### DIFF
--- a/.github/src/workflows/build_and_test.jinja2.yaml
+++ b/.github/src/workflows/build_and_test.jinja2.yaml
@@ -22,4 +22,4 @@ on:
 jobs:
   _ca6eacd0-46be-49b7-acf3-1e13fd2394c9:
     name: "Build and Test"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_Foundation/.github/workflows/exercise_main.yaml@CI-latest

--- a/.github/src/workflows/callable_create_stable_tag.jinja2.yaml
+++ b/.github/src/workflows/callable_create_stable_tag.jinja2.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: "[Impl] Dump Contexts"
-        uses: davidbrownell/v4-Common_Foundation/.github/actions/dump_contexts@CI-v1
+        uses: davidbrownell/v4-Common_Foundation/.github/actions/dump_contexts@CI-latest
 
       - name: Checkout source
         uses: actions/checkout@v3

--- a/.github/src/workflows/exercise_main.jinja2.yaml
+++ b/.github/src/workflows/exercise_main.jinja2.yaml
@@ -46,7 +46,7 @@ jobs:
           - python310
           # - python310_nolibs
 
-    uses: ./.github/workflows/exercise_main-Impl.yaml
+    uses: davidbrownell/v4-Common_Foundation/.github/workflows/exercise_main-Impl.yaml@CI-latest
     with:
       bootstrap_branch_overrides:           ${{ inputs.bootstrap_branch_overrides }}
       repo_name:                            ${{ inputs.repo_name }}

--- a/.github/src/workflows/main.jinja2.yaml
+++ b/.github/src/workflows/main.jinja2.yaml
@@ -20,13 +20,12 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   # ----------------------------------------------------------------------
   _1fc90631-2837-44fc-b70c-ea41ed5beae7:
     name: "Common_Foundation"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_Foundation/.github/workflows/exercise_main.yaml@CI-latest
     with:
       bootstrap_branch_overrides: "Common_Foundation:${{ github.ref_name }}"
       repo_name: "davidbrownell/v4-Common_Foundation"
@@ -57,7 +56,7 @@ jobs:
       - _5e328479-e73d-4578-8da8-4082491c40e9
       - _4f44cb3c-d033-4f8c-b666-2023304302f5
 
-    uses: ./.github/workflows/callable_create_stable_tag.yaml
+    uses: davidbrownell/v4-Common_Foundation/.github/workflows/callable_create_stable_tag.yaml@CI-latest
     with:
       branch: ${{ github.ref_name }}
       commit: ${{ github.sha }}

--- a/.github/src/workflows/on_pr_to_main.jinja2.yaml
+++ b/.github/src/workflows/on_pr_to_main.jinja2.yaml
@@ -24,4 +24,4 @@ on:
 jobs:
   _7a87a26d-b601-4b29-bb5e-e86ec174ac3b:
     name: "branch: ${{ github.base_ref }}"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_Foundation/.github/workflows/exercise_main.yaml@CI-latest

--- a/.github/src/workflows/periodic.jinja2.yaml
+++ b/.github/src/workflows/periodic.jinja2.yaml
@@ -24,6 +24,6 @@ on:
 jobs:
   _ef3d34c3-c4b9-4c67-8817-f6a7151893ea:
     name: "Build and Test"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_Foundation/.github/workflows/exercise_main.yaml@CI-latest
     with:
       repo_branch: main_stable

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -39,4 +39,4 @@ on:
 jobs:
   _ca6eacd0-46be-49b7-acf3-1e13fd2394c9:
     name: "Build and Test"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_Foundation/.github/workflows/exercise_main.yaml@CI-latest

--- a/.github/workflows/callable_create_stable_tag.yaml
+++ b/.github/workflows/callable_create_stable_tag.yaml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: "[Impl] Dump Contexts"
-        uses: davidbrownell/v4-Common_Foundation/.github/actions/dump_contexts@CI-v1
+        uses: davidbrownell/v4-Common_Foundation/.github/actions/dump_contexts@CI-latest
 
       - name: Checkout source
         uses: actions/checkout@v3

--- a/.github/workflows/exercise_main.yaml
+++ b/.github/workflows/exercise_main.yaml
@@ -63,7 +63,7 @@ jobs:
           - python310
           # - python310_nolibs
 
-    uses: ./.github/workflows/exercise_main-Impl.yaml
+    uses: davidbrownell/v4-Common_Foundation/.github/workflows/exercise_main-Impl.yaml@CI-latest
     with:
       bootstrap_branch_overrides:           ${{ inputs.bootstrap_branch_overrides }}
       repo_name:                            ${{ inputs.repo_name }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,13 +37,12 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   # ----------------------------------------------------------------------
   _1fc90631-2837-44fc-b70c-ea41ed5beae7:
     name: "Common_Foundation"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_Foundation/.github/workflows/exercise_main.yaml@CI-latest
     with:
       bootstrap_branch_overrides: "Common_Foundation:${{ github.ref_name }}"
       repo_name: "davidbrownell/v4-Common_Foundation"
@@ -74,7 +73,7 @@ jobs:
       - _5e328479-e73d-4578-8da8-4082491c40e9
       - _4f44cb3c-d033-4f8c-b666-2023304302f5
 
-    uses: ./.github/workflows/callable_create_stable_tag.yaml
+    uses: davidbrownell/v4-Common_Foundation/.github/workflows/callable_create_stable_tag.yaml@CI-latest
     with:
       branch: ${{ github.ref_name }}
       commit: ${{ github.sha }}

--- a/.github/workflows/on_pr_to_main.yaml
+++ b/.github/workflows/on_pr_to_main.yaml
@@ -41,4 +41,4 @@ on:
 jobs:
   _7a87a26d-b601-4b29-bb5e-e86ec174ac3b:
     name: "branch: ${{ github.base_ref }}"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_Foundation/.github/workflows/exercise_main.yaml@CI-latest

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -41,6 +41,6 @@ on:
 jobs:
   _ef3d34c3-c4b9-4c67-8817-f6a7151893ea:
     name: "Build and Test"
-    uses: ./.github/workflows/exercise_main.yaml
+    uses: davidbrownell/v4-Common_Foundation/.github/workflows/exercise_main.yaml@CI-latest
     with:
       repo_branch: main_stable

--- a/RepositoryBootstrap/Templates/.github/workflows/build_and_test.yaml
+++ b/RepositoryBootstrap/Templates/.github/workflows/build_and_test.yaml
@@ -7,4 +7,5 @@ on:
 jobs:
   _3708d875-b4c1-4265-89d0-93553e16c0c3:
     name: "Build and Test"
-    uses: ./.github/workflows/exercise_main.yaml
+    # "<< Populate (github_workflow): Specify the name of your repository on Github in the form '<username>/<repo_name>' (e.g. 'davidbrownell/v4-Common_PythonDevelopment') >>"
+    uses: <username>/<repo_name>/.github/workflows/exercise_main.yaml@CI-latest

--- a/RepositoryBootstrap/Templates/.github/workflows/main.yaml
+++ b/RepositoryBootstrap/Templates/.github/workflows/main.yaml
@@ -5,13 +5,13 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   _a3fa3751-1863-4670-a89c-3e60a602ac0f:
     name: "<< Populate (github_workflow): Friendly name of your repository>>"
 
-    uses: ./.github/workflows/exercise_main.yaml
+    # << Populate (github_workflow): Specify the name of your repository on Github in the form '<username>/<repo_name>' (e.g. 'davidbrownell/v4-Common_PythonDevelopment') >>
+    uses: <username>/<repo_name>/.github/workflows/exercise_main.yaml@CI-latest
     with:
       repo_name: "<< Populate (github_workflow): Specify the name of your repository on Github in the form '<username>/<repo_name>' (e.g. 'davidbrownell/v4-Common_PythonDevelopment') >>"
       repo_branch: "${{ github.ref_name }}"

--- a/RepositoryBootstrap/Templates/.github/workflows/periodic.yaml
+++ b/RepositoryBootstrap/Templates/.github/workflows/periodic.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   _76e87fa8-70a1-4edb-b1d2-aa24b6878b77:
     name: "Build and Test"
-    uses: ./.github/workflows/exercise_main.yaml
+    # "<< Populate (github_workflow): Specify the name of your repository on Github in the form '<username>/<repo_name>' (e.g. 'davidbrownell/v4-Common_PythonDevelopment') >>"
+    uses: <username>/<repo_name>/.github/workflows/exercise_main.yaml@CI-latest
     with:
       repo_branch: main_stable


### PR DESCRIPTION
Relative references weren't working when the script was invoked from a build associated with a different repo.