### PR TITLE
🐛 [-bug] Fixed regex issue when parsing kvps on the command line

### DIFF
--- a/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/TyperEx.py
+++ b/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/TyperEx.py
@@ -413,7 +413,7 @@ def _TyperImpl(
         regex = re.compile(
             r"""(?#
             Start of Line                   )^(?#
-            Key                             )(?P<key>_?[a-zA-Z][a-zA-Z0-9_-]*)(?#
+            Key                             )(?P<key>(?:\\[:=]|[^:=])+)(?#
             Optional Value Begin            )(?:(?#
                 Sep                         )\s*[:=]\s*(?#
                 Value                       )(?P<value>.+)(?#
@@ -433,8 +433,8 @@ def _TyperImpl(
                     ),
                 )
 
-            key = match.group("key")
-            value = match.group("value")
+            key = match.group("key").replace("\\:", ":").replace("\\=", "=")
+            value = match.group("value").replace("\\:", ":").replace("\\=", "=")
 
             arguments.append((key, value))
 


### PR DESCRIPTION
Keys were expected to be alpha-number chars, which didn't work well when the key-value-pairs represented drive values (e.g. "C:\") that needed replacement within a path string). Also added functionality to support escaping the kvp separator.