### PR TITLE
🎨 [refactor] Improved Build error message

### DIFF
--- a/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/BuildImpl/__init__.py
+++ b/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/BuildImpl/__init__.py
@@ -181,7 +181,7 @@ class BuildInfoBase(ABC):
                 dm.WriteInfo(
                     "This build can only be run in development environments activated with the {} {}; the current configuration is '{}'.".format(
                         inflect.plural("configuration", len(self.required_development_configurations)),
-                        ", ".join("'{}'".format(config) for config in self.required_development_configurations),
+                        ", ".join("'{}'".format(config.pattern) for config in self.required_development_configurations),
                         current_configuration,
                     ),
                 )


### PR DESCRIPTION
Improved error message when invoking a build that has been disabled for a configuration; previous code displayed the regex object. The regex string pattern is displayed with this change.