### PR TITLE
🐛 [-bugs] Various fixes

### DIFF
--- a/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/BuildImpl/__init__.py
+++ b/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/BuildImpl/__init__.py
@@ -46,6 +46,7 @@ except ModuleNotFoundError:
     sys.stdout.write("\nERROR: This script is not available in a 'nolibs' environment.\n")
     sys.exit(-1)
 
+from Common_Foundation import PathEx
 from Common_Foundation.Shell.All import CurrentShell
 from Common_Foundation.Streams.Capabilities import Capabilities
 from Common_Foundation.Streams.DoneManager import DoneManager, DoneManagerFlags
@@ -208,10 +209,10 @@ class BuildInfoBase(ABC):
                 return False
 
         if self.disable_if_dependency_environment:
-            filename = inspect.getsourcefile(type(self))
+            filename = PathEx.EnsureFile(Path(Types.EnsureValid(inspect.getsourcefile(type(self)))))
             assert filename is not None
 
-            if not filename.startswith(Types.EnsureValid(os.getenv("DEVELOPMENT_ENVIRONMENT_REPOSITORY"))):
+            if not PathEx.IsDescendant(filename, PathEx.EnsureDir(Path(Types.EnsureValid(os.getenv("DEVELOPMENT_ENVIRONMENT_REPOSITORY"))))):
                 dm.WriteInfo("This build can not be used when its repository is activated as a dependency repository.")
                 return False
 

--- a/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/ExecuteTasks.py
+++ b/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/ExecuteTasks.py
@@ -483,8 +483,16 @@ def _GenerateStatusInfo(
             with count_lock:
                 if task_data.result < 0:
                     error_count += 1
+
+                    if execute_dm.result >= 0:
+                        execute_dm.result = task_data.result
+
                 elif task_data.result > 0:
                     warning_count += 1
+
+                    if execute_dm.result == 0:
+                        execute_dm.result = task_data.result
+
                 else:
                     success_count += 1
 
@@ -683,11 +691,8 @@ def _GenerateProgressStatusInfo(
         def OnTaskDataComplete(
             task_data: TaskData,
         ) -> None:
-            if task_data.result < 0:
-                if dm.result >= 0:
-                    dm.result = task_data.result
-
-                if not quiet:
+            if not quiet:
+                if task_data.result < 0:
                     assert TextwrapEx.ERROR_COLOR_ON == "\033[31;1m", "Ensure that the colors stay in sync"
 
                     progress_bar.print(
@@ -705,11 +710,7 @@ def _GenerateProgressStatusInfo(
 
                     stdout_context.persist_content = True
 
-            if task_data.result > 0:
-                if dm.result == 0:
-                    dm.result = task_data.result
-
-                if not quiet:
+                elif task_data.result > 0:
                     assert TextwrapEx.WARNING_COLOR_ON == "\033[33;1m", "Ensure that the colors stay in sync"
 
                     progress_bar.print(


### PR DESCRIPTION
- 🐛 [-bug] Fixed regression with ExecuteTasks where errors weren't properly displayed when running with the noop stream
- 🐛 [-bug] Fixed issue in detecting dependency environment during build when non-standard path separators are used when launching the build file