### PR TITLE
🐛 [-bug] Fixed issue when attempting to display some test names

### DIFF
--- a/Scripts/Tester/DisplayResults.py
+++ b/Scripts/Tester/DisplayResults.py
@@ -109,7 +109,7 @@ def Display(
 
         return "\n".join(
             "{} {}".format(
-                "{}:".format(k).ljust(col_width),
+                "{}:".format(k.replace("[", "\\[")).ljust(col_width),
                 v,
             )
             for k, v in values.items()


### PR DESCRIPTION
Test names with "[/]" would cause problems with the python rich library (which interprets those characters as markup formatting tokens). Now escaping '[' characters to prevent that from happening.