### PR TITLE
🎨 [refactor] Changed location of DynamicPluginArchitecture.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ Tools/Python/v3.10.6/Windows/x64/*/**
 
 Libraries/Python/Common_Foundation/src/Common_Foundation.egg-info/*
 Libraries/Python/Common_FoundationEx/src/Common_FoundationEx.egg-info/*
+
+RepositoryBootstrap/SetupAndActivate/DynamicPluginArchitecture.py

--- a/Activate_custom.py
+++ b/Activate_custom.py
@@ -20,16 +20,16 @@ from pathlib import Path
 from typing import List, Optional
 
 from Common_Foundation.ContextlibEx import ExitStack
-from Common_Foundation.Shell import Commands  # type: ignore
-from Common_Foundation.Shell.All import CurrentShell  # type: ignore
+from Common_Foundation import DynamicPluginArchitecture                     # type: ignore
+from Common_Foundation.Shell import Commands                                # type: ignore
+from Common_Foundation.Shell.All import CurrentShell                        # type: ignore
 from Common_Foundation.SourceControlManagers.GitSourceControlManager import GitSourceControlManager
-from Common_Foundation.Streams.DoneManager import DoneManager  # type: ignore
-from Common_Foundation import SubprocessEx  # type: ignore
-from Common_Foundation import TextwrapEx  # type: ignore
+from Common_Foundation.Streams.DoneManager import DoneManager               # type: ignore
+from Common_Foundation import SubprocessEx                                  # type: ignore
+from Common_Foundation import TextwrapEx                                    # type: ignore
 
 from RepositoryBootstrap import Constants
 from RepositoryBootstrap.Impl.ActivateActivities.ScriptsActivateActivity import Extractor, ExtractorMap
-from RepositoryBootstrap.SetupAndActivate import DynamicPluginArchitecture
 
 
 # ----------------------------------------------------------------------

--- a/Libraries/Python/Common_Foundation/src/Common_Foundation/DynamicPluginArchitecture.py
+++ b/Libraries/Python/Common_Foundation/src/Common_Foundation/DynamicPluginArchitecture.py
@@ -48,8 +48,6 @@ from Common_Foundation.Shell.All import CurrentShell
 from Common_Foundation.Streams.DoneManager import DoneManager
 from Common_Foundation.Streams.StreamDecorator import StreamDecorator
 
-from .. import Constants as RepositoryBootstrapConstants
-
 
 # ----------------------------------------------------------------------
 def EnumeratePlugins(
@@ -152,7 +150,7 @@ def CreateRegistrationCommands(
         source_filename = os.getenv(environment_var_name)
         if force or not source_filename:
             source_filename = CurrentShell.CreateTempFilename(
-                ".DynamicPluginArchitecture{}".format(RepositoryBootstrapConstants.TEMPORARY_FILE_EXTENSION),
+                ".DynamicPluginArchitecture.SourceRepositoryTools",
             )
 
             source_filename_str = str(source_filename)

--- a/Scripts/Tester/CommandLineImpl.py
+++ b/Scripts/Tester/CommandLineImpl.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import typer
 
-from Common_Foundation.ContextlibEx import ExitStack
+from Common_Foundation import DynamicPluginArchitecture
 from Common_Foundation import EnumSource
 from Common_Foundation.Shell.All import CurrentShell
 from Common_Foundation.Streams.DoneManager import DoneManager, DoneManagerFlags
@@ -43,14 +43,6 @@ import DisplayResults
 from ExecuteTests import ExecuteTests
 from Results import FindResult
 from TestTypes import TYPES as TEST_TYPE_INFOS
-
-
-# ----------------------------------------------------------------------
-sys.path.insert(0, Types.EnsureValid(os.getenv("DEVELOPMENT_ENVIRONMENT_FOUNDATION")))
-with ExitStack(lambda: sys.path.pop(0)):
-    assert os.path.isdir(sys.path[0]), sys.path[0]
-
-    from RepositoryBootstrap.SetupAndActivate import DynamicPluginArchitecture  # pylint: disable=import-error
 
 
 # ----------------------------------------------------------------------

--- a/Setup_custom.py
+++ b/Setup_custom.py
@@ -15,10 +15,12 @@
 # ----------------------------------------------------------------------
 # pylint: disable=missing-module-docstring
 
+from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 from semantic_version import Version as SemVer
 
+from Common_Foundation import PathEx
 from Common_Foundation.Shell.All import CurrentShell  # type: ignore
 from Common_Foundation.Shell import Commands  # type: ignore
 
@@ -93,4 +95,22 @@ def GetConfigurations() -> Union[Configuration.Configuration, Dict[str, Configur
 def GetCustomActions(
     explicit_configurations: Optional[List[str]],  # pylint: disable=unused-argument
 ) -> List[Commands.Command]:
-    return []
+    commands: list[Commands.Command] = []
+
+    root_dir = Path(__file__).parent
+
+    # At one point, DynamicPluginArchitecture lived in './RepositoryBootstrap/SetupAndActivate' but
+    # it now lives in './Libraries/Python/Common_Foundation/src/Common_Foundation'. Create a link to
+    # the new file at the previous location to maintain backwards compatibility.
+    current_filename = PathEx.EnsureFile(root_dir / "Libraries" / "Python" / "Common_Foundation" / "src" / "Common_Foundation" / "DynamicPluginArchitecture.py")
+
+    commands.append(
+        Commands.SymbolicLink(
+            PathEx.EnsureDir(root_dir / "RepositoryBootstrap" / "SetupAndActivate") / current_filename.name,
+            current_filename,
+            remove_existing=True,
+            relative_path=True,
+        ),
+    )
+
+    return commands


### PR DESCRIPTION
Changed location of file so that it can be more easily consumed by bundled python binaries (without consuming all of RepositoryBootstrap (as it would have if left in its previous location)).