### PR TITLE
✨ [+feature],🎨 [refactor] Multiple changes

### DIFF
--- a/Libraries/Python/Common_Foundation/src/Common_Foundation/ContextlibEx.py
+++ b/Libraries/Python/Common_Foundation/src/Common_Foundation/ContextlibEx.py
@@ -16,14 +16,14 @@
 """Enhancements to the contextlib package"""
 
 from contextlib import contextmanager, ExitStack as ExitStackImpl
-from typing import Any, Callable
+from typing import Any, Callable, Iterator
 
 
 # ----------------------------------------------------------------------
 @contextmanager
 def ExitStack(
     *args: Callable[[], Any],
-):
+) -> Iterator[Any]:
     with ExitStackImpl() as exit_stack:
         for arg in args:
             exit_stack.callback(arg)

--- a/Libraries/Python/Common_Foundation/src/Common_Foundation/SourceControlManagers/GitSourceControlManager.py
+++ b/Libraries/Python/Common_Foundation/src/Common_Foundation/SourceControlManagers/GitSourceControlManager.py
@@ -927,7 +927,13 @@ class Repository(DistributedRepositoryBase):
         self,
         branch_or_branches: Union[None, str, List[str]]=None,
     ) -> str:
-        commands: List[str] = []
+        commands: List[str] = [
+            # Git cannot fetch content for tags that it doesn't know about, but we don't know if the
+            # branches provided (if any) are tags or branches. We erring on the side of correctness
+            # here and pull all of the tags before we attempt to fetch content based on what is
+            # potentially a tag name. Stupid git.
+            "git fetch --all --tags --force",
+        ]
 
         if branch_or_branches:
             if isinstance(branch_or_branches, list):
@@ -941,10 +947,7 @@ class Repository(DistributedRepositoryBase):
             ]
 
         else:
-            commands += [
-                "git fetch --all",
-                "git fetch --all --tags --force",
-            ]
+            commands.append("git fetch --all")
 
         return self._GetCommandLine(" && ".join(commands))
 

--- a/Libraries/Python/Common_Foundation/src/Common_Foundation/TextwrapEx.py
+++ b/Libraries/Python/Common_Foundation/src/Common_Foundation/TextwrapEx.py
@@ -430,10 +430,10 @@ def CreateText(
             # The indent is the length of the prefix without color decorations
             len(
                 create_prefix_func(
-                    Capabilities.Alter(
+                    Capabilities.Clone(
                         sys.stdout,
                         supports_colors=False,
-                    )[1],
+                    ),
                 ),
             ),
             skip_first_line=True,

--- a/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/CompilerImpl/CompilerImpl.py
+++ b/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/CompilerImpl/CompilerImpl.py
@@ -269,11 +269,25 @@ class CompilerImpl(
         assert False, self.input_type  # pragma: no cover
 
     # ----------------------------------------------------------------------
+    @extensionmethod
+    def ValidateMetadata(
+        self,
+        dm: DoneManager,                    # pylint: disable=unused-argument
+        metadata: dict[str, Any],           # pylint: disable=unused-argument
+    ) -> None:
+        """Validates metadata before it is converted into context items"""
+
+        # No validation by default
+        return
+
+    # ----------------------------------------------------------------------
     def GenerateContextItems(
         self,
         dm: DoneManager,
         input_or_inputs: Union[Path, List[Path]],
         metadata: Dict[str, Any],
+        *,
+        do_not_decorate_output_dir_with_index: bool=False,
     ) -> Generator[Dict[str, Any], None, None]:
         """\
         Generates one or more context items based on the provided metadata input.
@@ -376,8 +390,8 @@ class CompilerImpl(
 
                         metadata["output_dir"] /= Path(*input_dir.parts[len_item_root_parts:])
                     elif "inputs" in metadata:
-                        if len(all_input_items) != 1:
-                            metadata["output_dir"] /= str(index)
+                        if not do_not_decorate_output_dir_with_index:
+                            metadata["output_dir"] /= "{:06}".format(index)
                     else:
                         assert False, metadata  # pragma: no cover
 

--- a/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/CompilerImpl/PluginBase.py
+++ b/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/CompilerImpl/PluginBase.py
@@ -24,6 +24,8 @@ from typing import Any, Optional
 
 from Common_Foundation.Types import extensionmethod
 
+from Common_FoundationEx import TyperEx
+
 
 # ----------------------------------------------------------------------
 class PluginBase(ABC):
@@ -63,11 +65,18 @@ class PluginBase(ABC):
 
     # ----------------------------------------------------------------------
     @abstractmethod
+    def GetCommandLineArgs(self) -> TyperEx.TypeDefinitionsType:
+        """Return command line arguments required by the plugin"""
+
+        raise Exception("Abstract method")  # pragma: no cover
+
+    # ----------------------------------------------------------------------
+    @abstractmethod
     def GetNumAdditionalSteps(
         self,
         context: dict[str, Any],
     ) -> int:
-        raise Exception("Abstract method")
+        raise Exception("Abstract method")  # pragma: no cover
 
     # ----------------------------------------------------------------------
     # |

--- a/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/ExecuteTasks.py
+++ b/Libraries/Python/Common_FoundationEx/src/Common_FoundationEx/ExecuteTasks.py
@@ -27,7 +27,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, cast, Iterator, List, Optional, Protocol, Tuple, TypeVar
+from typing import Any, Callable, cast, Iterator, List, Optional, Protocol, Tuple, TypeVar, Union
 from unittest.mock import MagicMock
 
 from rich.progress import Progress, TaskID, TimeElapsedColumn
@@ -239,7 +239,13 @@ def Transform(
     refresh_per_second: Optional[float]=None,
     no_compress_tasks: bool=False,
     return_exceptions: bool=False,
-) -> List[Optional[TransformedType]]:
+) -> List[
+    Union[
+        None,
+        TransformedType,
+        Exception,                          # If 'return_exceptions' is True
+    ],
+]:
     """Executes functions that return values"""
 
     with _YieldTemporaryDirectory(dm) as temp_directory:
@@ -972,8 +978,14 @@ def _TransformStandard(
     num_threads: int,
     refresh_per_second: Optional[float],
     return_exceptions: bool,
-) -> List[Optional[TransformedType]]:
-    all_results: List[Optional[TransformedType]] = [None for _ in range(len(tasks))]
+) -> List[
+    Union[
+        None,
+        TransformedType,
+        Exception,                          # If 'return_exceptions' is True
+    ],
+]:
+    all_results: List[Union[None, TransformedType, Exception]] = [None for _ in range(len(tasks))]
 
     # Update the task context with task index
     for task_index, task in enumerate(tasks):
@@ -1052,10 +1064,16 @@ def _TransformCompressed(
     num_threads: int,
     refresh_per_second: Optional[float],
     return_exceptions: bool,
-) -> List[Optional[TransformedType]]:
+) -> List[
+    Union[
+        None,
+        TransformedType,
+        Exception,                          # If 'return_exceptions' is True
+    ],
+]:
     assert num_threads != 1
 
-    all_results: List[Optional[TransformedType]] = [None for _ in range(len(tasks))]
+    all_results: List[Union[None, TransformedType, Exception]] = [None for _ in range(len(tasks))]
 
     with _GenerateStatusInfo(
         len(tasks),

--- a/RepositoryBootstrap/Impl/Activate.py
+++ b/RepositoryBootstrap/Impl/Activate.py
@@ -60,7 +60,7 @@ class NaturalOrderGrouper(TyperGroup):
 app                                         = typer.Typer(
     cls=NaturalOrderGrouper,
     no_args_is_help=True,
-    pretty_exceptions_enable=False,
+    pretty_exceptions_show_locals=False,
 )
 
 

--- a/RepositoryBootstrap/Impl/Enlist.py
+++ b/RepositoryBootstrap/Impl/Enlist.py
@@ -64,7 +64,7 @@ class NaturalOrderGrouper(TyperGroup):
 app                                         = typer.Typer(
     cls=NaturalOrderGrouper,
     no_args_is_help=True,
-    pretty_exceptions_enable=False,
+    pretty_exceptions_show_locals=False,
 )
 
 

--- a/RepositoryBootstrap/Impl/Setup.py
+++ b/RepositoryBootstrap/Impl/Setup.py
@@ -70,7 +70,7 @@ class NaturalOrderGrouper(TyperGroup):
 app                                         = typer.Typer(
     cls=NaturalOrderGrouper,
     no_args_is_help=True,
-    pretty_exceptions_enable=False,
+    pretty_exceptions_show_locals=False,
 )
 
 

--- a/Scripts/Builder/__main__.py
+++ b/Scripts/Builder/__main__.py
@@ -848,6 +848,8 @@ def _GetBuildInfos(
             if result is None:
                 continue
 
+            assert not isinstance(result, Exception), result
+
             build_infos.append(result)
 
     results: Dict[int, Dict[Path, BuildInfoBase]] = {}


### PR DESCRIPTION
- ✨ [+feature] Added plugin support to the compiler infrastructure
- ✨ [+feature] DoneManager now prevents typer from displaying exceptions on exit if they have already been displayed.
- ✨ [+feature] Added compiler feature to validate metadata before using it to generate contexts (this helps with earlier error reporting if the metadata is invalid).
- ✨ [+feature] Added independent methods to clone and use stream capabilities.
- 🎨 [refactor] Refactored the CodeGeneratorPluginHostMixin and PluginBase based on requirements from Common_SimpleSchema
- 🎨 [refactor] Moved code to dynamically create python function arguments based on typer.models.OptionInfo to a central location in TyperEx (as it was being used by code generator plugins as well)
- 🎨 [refactor] Pulling all git tags as a part of Pull.
- 🎨 [refactor] Added missing type hints.