### PR TITLE
🐛 [-bug] No longer raising on error when listing configurations

### DIFF
--- a/RepositoryBootstrap/Impl/Hooks/HookImpl.py
+++ b/RepositoryBootstrap/Impl/Hooks/HookImpl.py
@@ -161,8 +161,6 @@ def GetPlugins(
                 '"{}" ListConfigurations --display-format json'.format(activate_filename),
             )
 
-            result.RaiseOnError()
-
             json_content = json.loads(result.output)
 
             if len(json_content) == 1 and "null" in json_content:


### PR DESCRIPTION
Invoking `Activate.sh ListConfigurations` on Linux returns in a failure result code, which isn't actually a failure here.