### PR TITLE
📌 [pinned_dependency] Pinned pydantic to 1.10

### DIFF
--- a/Setup_custom.py
+++ b/Setup_custom.py
@@ -52,6 +52,12 @@ def GetConfigurations() -> Union[Configuration.Configuration, Dict[str, Configur
         Configuration.VersionInfo("jinja2", SemVer("3.1.2")),
         Configuration.VersionInfo("jsonschema", SemVer.coerce("4.17.3")),
         Configuration.VersionInfo("rtyaml", SemVer("1.0.0")),
+
+        # Libraries required to work around build breaks
+
+        # inflect requires pydantic, but does so with ">=". Pydantic 2.0 introduces breaking changes,
+        # which cause inflect to fail. Pin pydantic to a pre 2.0 version.
+        Configuration.VersionInfo("pydantic", SemVer("1.10.10")),
     ]
 
     if CurrentShell.family_name == "Windows":

--- a/Tools/Python/v3.10.6/Darwin/Setup.sh
+++ b/Tools/Python/v3.10.6/Darwin/Setup.sh
@@ -44,16 +44,17 @@ fi
 setup_python_binary=/Library/Frameworks/Python.framework/Versions/3.10/bin/python3
 
 /Library/Frameworks/Python.framework/Versions/3.10/bin/pip3 install --disable-pip-version-check \
-    setuptools==63.2.0 \
-    virtualenv==20.16.3 \
-    wheel==0.37.1 \
-    colorama==0.4.5 \
-    distro==1.7.0 \
-    inflect==6.0.0 \
-    requests==2.28.1 \
-    rich==12.6.0 \
-    semantic_version==2.10.0 \
-    typer==0.6.1 \
-    wrapt==1.14.1
+    setuptools~=63.2 \
+    virtualenv~=20.16 \
+    wheel~=0.37 \
+    colorama~=0.4 \
+    distro~=1.7 \
+    inflect~=6.0 \
+    pydantic~=1.10 \
+    requests~=2.28 \
+    rich~=12.6 \
+    semantic_version~=2.10 \
+    typer~=0.6 \
+    wrapt~=1.14
 
 popd > /dev/null                            # -dir


### PR DESCRIPTION
Pre-pinned version of pydantic so that inflect won't try to install v2.0 of the library, which introduces changes that break inflect.