### PR TITLE
🐛 [-bug] Addressed bug in DoneManager

### DIFF
--- a/Libraries/Python/Common_Foundation/src/Common_Foundation/Streams/DoneManager.py
+++ b/Libraries/Python/Common_Foundation/src/Common_Foundation/Streams/DoneManager.py
@@ -302,17 +302,26 @@ class DoneManager(object):
         stream: Union[StreamDecorator, TextIO, TextWriter]=sys.stdout,
         *,
         output_flags: DoneManagerFlags=DoneManagerFlags.Standard,
+        display: bool=True,
         **kwargs,
     ) -> Iterator["DoneManager"]:
         """Creates a DoneManager suitable for use with a command-line application"""
+
+        if display:
+            prefix="\nResults: "
+            suffix = "\n"
+        else:
+            prefix = ""
+            suffix = ""
 
         with cls.Create(
             stream,
             "\n",
             line_prefix="",
-            prefix="\nResults: ",
-            suffix="\n",
+            prefix=prefix,
+            suffix=suffix,
             output_flags=output_flags,
+            display=display,
             **kwargs,
         ) as dm:
             is_exceptional = False

--- a/Libraries/Python/Common_Foundation/src/__version__.py
+++ b/Libraries/Python/Common_Foundation/src/__version__.py
@@ -15,4 +15,4 @@
 # ----------------------------------------------------------------------
 # pylint: disable=invalid-name,missing-module-docstring
 #
-VERSION = "0.5.5"
+VERSION = "0.5.6"


### PR DESCRIPTION
Fixed issue where "Results: " prefix was displayed when the display value was set to False (the default is True).