### PR TITLE
🐛 [-bug] Prevent the enumeration of the template dir

### DIFF
--- a/RepositoryBootstrap/Impl/Utilities.py
+++ b/RepositoryBootstrap/Impl/Utilities.py
@@ -106,9 +106,9 @@ def GetRepoData(
         return None
 
     name = match.group("name")
+    id = match.group("id")
 
     try:
-        id = match.group("id")
         id = uuid.UUID(match.group("id"))
     except ValueError:
         raise Exception("'{}' is not a valid uuid.".format(id))

--- a/RepositoryBootstrap/RepositoryTemplate/IgnoreAsBootstrapDependency
+++ b/RepositoryBootstrap/RepositoryTemplate/IgnoreAsBootstrapDependency
@@ -1,0 +1,3 @@
+Do not search this directory when looking for repo dependencies. Without this file, directory
+enumeration will raise an exception when attempting to parse the invalid uuid in
+./{{ cookiecutter._empty }}/__RepositoryId__.json.


### PR DESCRIPTION
Do not include the template directory when searching for dependencies during the bootstrap process.