### PR TITLE
🐛 [-bug] Fixed bugs calculating git changes in some scenarios

### DIFF
--- a/RepositoryBootstrap/Impl/Hooks/GitHooks.py
+++ b/RepositoryBootstrap/Impl/Hooks/GitHooks.py
@@ -449,8 +449,10 @@ def _ParseGitOutput(
     result = GitSourceControlManager.Execute(
         command_line,
         cwd=repository_root,
-        strip=True,
+        strip=False,
     )
+
+    result.output = result.output.rstrip()
 
     dm.result = result.returncode
 


### PR DESCRIPTION
Stripping the git output when extracting changes would fail when the first line in the output started with a space as that space was being removed with the output was stripped. Now only stripping trailing whitespace.