### PR TITLE
👽️ [external_api_change] AutoSemVer images suppress git errors

### DIFF
--- a/src/AutoSemVer/BuildEnvironment/Build.py
+++ b/src/AutoSemVer/BuildEnvironment/Build.py
@@ -323,6 +323,11 @@ def CreateDockerImage(
                                 && apt install -y git mercurial \\
                                 && rm -rf /var/lib/apt/lists/*
 
+                            # Prevent git from generating errors about permission differences on directories, especially
+                            # when those directories will be mounted via docker volumes. It would be unwise to set this
+                            # configuration value in most other scenarios.
+                            RUN git config --global --add safe.directory '*'
+
                             RUN mkdir AutoSemVer
                             WORKDIR AutoSemVer
 


### PR DESCRIPTION
Updated the AutoSemVer container image so that git no longer issues errors about unsafe directories when runnin. Given the way in which this image is used, all directories passed to git (via AutoSemVer) will be considered unsafe as they are exposed via mounted docker volumes to support semantic version calculation on repositories located on the host machine.