### PR TITLE
🐛 [-bug] Normalizing branch names for AutoSemVer

### DIFF
--- a/src/AutoSemVer/src/AutoSemVerLib.py
+++ b/src/AutoSemVer/src/AutoSemVerLib.py
@@ -367,6 +367,9 @@ def GetSemanticVersion(
             if configuration.include_branch_name_when_necessary and include_branch_name_when_necessary:
                 current_branch = repository.GetCurrentNormalizedBranch()
 
+                # Remove any path parts from the branch name
+                current_branch = current_branch.split("/")[-1]
+
                 if current_branch not in configuration.main_branch_names:
                     prerelease_components.append(current_branch)
 


### PR DESCRIPTION
A recent change to git branch name extraction created the scenario where branch names may contain slashes (which breaks some components that use AutoSemVer). The last part of the branch will be used with this change.